### PR TITLE
add ExPlasma.Transaction.to_map/1

### DIFF
--- a/lib/ex_plasma/transaction.ex
+++ b/lib/ex_plasma/transaction.ex
@@ -248,7 +248,7 @@ defmodule ExPlasma.Transaction do
     ## Examples
 
       # Signs transaction with the given key.
-      iex> txn = %ExPlasma.Transaction{metadata: <<0::160>>} 
+      iex> txn = %ExPlasma.Transaction{metadata: <<0::160>>}
       iex> key = "0x79298b0292bbfa9b15705c56b6133201c62b798f102d7d096d31d7637f9b2382"
       iex> ExPlasma.Transaction.sign(txn, keys: [key])
       %ExPlasma.Transaction{
@@ -265,7 +265,7 @@ defmodule ExPlasma.Transaction do
       }
 
       # Signs the transaction with no keys.
-      iex> txn = %ExPlasma.Transaction{metadata: <<0::160>>} 
+      iex> txn = %ExPlasma.Transaction{metadata: <<0::160>>}
       iex> ExPlasma.Transaction.sign(txn, keys: [])
       %ExPlasma.Transaction{
         inputs: [],
@@ -281,6 +281,20 @@ defmodule ExPlasma.Transaction do
     eip712_hash = ExPlasma.TypedData.hash(transaction)
     sigs = Enum.map(keys, fn key -> ExPlasma.Encoding.signature_digest(eip712_hash, key) end)
     %{transaction | sigs: sigs}
+  end
+
+  @doc """
+  Converts a transaction and its members into a map.
+  """
+  @spec to_map(struct()) :: map()
+  def to_map(transaction) do
+    params = Map.from_struct(transaction)
+
+    %{
+      params
+      | inputs: Enum.map(transaction.inputs, &Map.from_struct/1),
+        outputs: Enum.map(transaction.outputs, &Map.from_struct/1)
+    }
   end
 
   # Builds list of utxos and propogates error tuples up the stack.

--- a/test/ex_plasma/transaction_test.exs
+++ b/test/ex_plasma/transaction_test.exs
@@ -172,6 +172,76 @@ defmodule ExPlasma.TransactionTest do
                0, 0, 0, 0, 0, 0>>
   end
 
+  test "map/1 turns struct into map" do
+    txn = %ExPlasma.Transaction{
+      inputs: [
+        %ExPlasma.Utxo{
+          amount: nil,
+          blknum: 0,
+          currency: nil,
+          oindex: 0,
+          output_type: 1,
+          owner: nil,
+          txindex: 0
+        }
+      ],
+      metadata: <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>,
+      outputs: [
+        %ExPlasma.Utxo{
+          amount: 1,
+          blknum: nil,
+          currency:
+            <<46, 38, 45, 41, 28, 46, 150, 159, 176, 132, 157, 153, 217, 206, 65, 226, 241, 55, 0,
+              110>>,
+          oindex: nil,
+          output_type: 1,
+          owner:
+            <<29, 246, 47, 41, 27, 46, 150, 159, 176, 132, 157, 153, 217, 206, 65, 226, 241, 55,
+              0, 110>>,
+          txindex: nil
+        }
+      ],
+      sigs: [],
+      tx_data: 0,
+      tx_type: 1
+    }
+
+    map = ExPlasma.Transaction.to_map(txn)
+
+    assert map == %{
+             inputs: [
+               %{
+                 amount: nil,
+                 blknum: 0,
+                 currency: nil,
+                 oindex: 0,
+                 output_type: 1,
+                 owner: nil,
+                 txindex: 0
+               }
+             ],
+             metadata: <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>>,
+             outputs: [
+               %{
+                 amount: 1,
+                 blknum: nil,
+                 currency:
+                   <<46, 38, 45, 41, 28, 46, 150, 159, 176, 132, 157, 153, 217, 206, 65, 226, 241,
+                     55, 0, 110>>,
+                 oindex: nil,
+                 output_type: 1,
+                 owner:
+                   <<29, 246, 47, 41, 27, 46, 150, 159, 176, 132, 157, 153, 217, 206, 65, 226,
+                     241, 55, 0, 110>>,
+                 txindex: nil
+               }
+             ],
+             sigs: [],
+             tx_data: 0,
+             tx_type: 1
+           }
+  end
+
   describe "TypedData" do
     test "encode/1 encodes a transaction eip 712 object" do
       encoded = ExPlasma.TypedData.encode(%Transaction{})


### PR DESCRIPTION
Add a simple `to_map/1` function to allow producing deep nested structs into maps. This is useful for consumption by Ecto.