### PR TITLE
Fix Dialyzer Warnings for Elixir 1.10.2

### DIFF
--- a/lib/ex_plasma.ex
+++ b/lib/ex_plasma.ex
@@ -131,7 +131,7 @@ defmodule ExPlasma do
        }}
   """
   @spec decode(Transaction.rlp() | Utxo.output_rlp() | Utxo.input_rlp()) ::
-          {:ok, Transaction.t()} | {:ok, Utxo.t()} | Utxo.validation_tuples()
+          {:ok, Transaction.t()} | {:ok, Utxo.t()} | {:error, Utxo.validation_tuples()}
   def decode([_output_type, [_owner, _currency, _amount]] = output_rlp), do: Utxo.new(output_rlp)
 
   def decode([_tx_type, _inputs, _outputs, _tx_data, _metadata] = tx_rlp),

--- a/lib/ex_plasma/block.ex
+++ b/lib/ex_plasma/block.ex
@@ -34,7 +34,7 @@ defmodule ExPlasma.Block do
       ]
     }
   """
-  @spec new(maybe_improper_list()) :: __MODULE__.t()
+  @spec new(maybe_improper_list()) :: %__MODULE__{hash: binary(), timestamp: nil, transactions: maybe_improper_list}
   def new(transactions) when is_list(transactions),
     do: %__MODULE__{transactions: transactions, hash: merkle_root_hash(transactions)}
 

--- a/lib/ex_plasma/block.ex
+++ b/lib/ex_plasma/block.ex
@@ -34,7 +34,11 @@ defmodule ExPlasma.Block do
       ]
     }
   """
-  @spec new(maybe_improper_list()) :: %__MODULE__{hash: binary(), timestamp: nil, transactions: maybe_improper_list}
+  @spec new(maybe_improper_list()) :: %__MODULE__{
+          hash: binary(),
+          timestamp: nil,
+          transactions: maybe_improper_list
+        }
   def new(transactions) when is_list(transactions),
     do: %__MODULE__{transactions: transactions, hash: merkle_root_hash(transactions)}
 

--- a/lib/ex_plasma/utxo.ex
+++ b/lib/ex_plasma/utxo.ex
@@ -52,8 +52,8 @@ defmodule ExPlasma.Utxo do
   @type input_t :: %__MODULE__{
           blknum: non_neg_integer(),
           oindex: non_neg_integer(),
-          txindex: non_neg_integer(),
-  }
+          txindex: non_neg_integer()
+        }
 
   # Also known as the Utxo position
   @type input_rlp :: non_neg_integer() | binary()

--- a/lib/ex_plasma/utxo.ex
+++ b/lib/ex_plasma/utxo.ex
@@ -49,6 +49,12 @@ defmodule ExPlasma.Utxo do
           owner: address_binary() | address_hex() | nil
         }
 
+  @type input_t :: %__MODULE__{
+          blknum: non_neg_integer(),
+          oindex: non_neg_integer(),
+          txindex: non_neg_integer(),
+  }
+
   # Also known as the Utxo position
   @type input_rlp :: non_neg_integer() | binary()
   @type output_rlp :: nonempty_list()
@@ -211,7 +217,7 @@ defmodule ExPlasma.Utxo do
     <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
       0, 0, 0, 0, 0, 0, 119, 53, 187, 17>>
   """
-  @spec to_input_rlp(__MODULE__.t() | input_map()) :: binary()
+  @spec to_input_rlp(__MODULE__.input_t() | input_map()) :: binary()
   def to_input_rlp(%{blknum: blknum, oindex: oindex, txindex: txindex} = utxo)
       when is_integer(blknum) and is_integer(oindex) and is_integer(txindex) do
     utxo |> pos() |> :binary.encode_unsigned(:big) |> pad_binary()


### PR DESCRIPTION
This fixes the dialyzer warnings for elixir `1.10.2`

Specifically, want to fix the `ExPlasma.decode/1` spec so that downstream applications would work.

Upon using `1.10.2`, 2 more dialyzer errors occurred as seen in this PR.