### PR TITLE
txbytes -> tx_bytes

### DIFF
--- a/lib/ex_plasma.ex
+++ b/lib/ex_plasma.ex
@@ -110,7 +110,7 @@ defmodule ExPlasma do
   }
   """
   @spec decode(binary()) :: Transaction.t()
-  def decode(txbytes), do: Transaction.decode(txbytes)
+  def decode(tx_bytes), do: Transaction.decode(tx_bytes)
 
   @doc """
   Keccak hash the Transaction. This is used in the contracts and events to to reference transactions.

--- a/lib/ex_plasma/in_flight_exit.ex
+++ b/lib/ex_plasma/in_flight_exit.ex
@@ -9,9 +9,9 @@ defmodule ExPlasma.InFlightExit do
 
   See https://github.com/omisego/plasma-contracts/blob/v1.0.3/plasma_framework/contracts/src/exits/utils/ExitId.sol#L53-L55
   """
-  @spec txbytes_to_id(binary()) :: pos_integer()
-  def txbytes_to_id(txbytes) do
-    txbytes
+  @spec tx_bytes_to_id(binary()) :: pos_integer()
+  def tx_bytes_to_id(tx_bytes) do
+    tx_bytes
     |> ExPlasma.Encoding.keccak_hash()
     |> :binary.decode_unsigned()
     |> Bitwise.>>>(105)

--- a/test/conformance/in_flight_exit_test.exs
+++ b/test/conformance/in_flight_exit_test.exs
@@ -21,11 +21,11 @@ defmodule Conformance.InFlightExitTest do
     "0xffffffffffffffffffffffffffffffff"
   ]
 
-  describe "txbytes_to_id/1" do
+  describe "tx_bytes_to_id/1" do
     test "matches PaymentExitGame.getInFlightExitId(bytes)" do
       Enum.each(@ife_tx_hexes, fn hex ->
-        txbytes = ExPlasma.Encoding.to_binary(hex)
-        assert InFlightExit.txbytes_to_id(txbytes) == contract_get_in_flight_exit_id(txbytes)
+        tx_bytes = ExPlasma.Encoding.to_binary(hex)
+        assert InFlightExit.tx_bytes_to_id(tx_bytes) == contract_get_in_flight_exit_id(tx_bytes)
       end)
     end
   end

--- a/test/ex_plasma/in_flight_exit_test.exs
+++ b/test/ex_plasma/in_flight_exit_test.exs
@@ -5,8 +5,8 @@ defmodule ExPlasma.InFlightExitTest do
 
   doctest ExPlasma.InFlightExit
 
-  describe "txbytes_to_id/1" do
-    test "basic txbytes is converted to the correct IDs" do
+  describe "tx_bytes_to_id/1" do
+    test "basic tx_bytes is converted to the correct IDs" do
       # The right hand side of these assertions are collected from this contract, a stripped down version
       # of https://github.com/omisego/plasma-contracts/blob/v1.0.3/plasma_framework/contracts/src/exits/utils/ExitId.sol#L53-L55
       #
@@ -23,28 +23,28 @@ defmodule ExPlasma.InFlightExitTest do
       #         return _self | ONE << _index;
       #     }
       # }
-      assert InFlightExit.txbytes_to_id(to_binary("0x")) ==
+      assert InFlightExit.tx_bytes_to_id(to_binary("0x")) ==
                5_060_277_488_387_867_361_168_243_832_726_934_991_540_486_235
 
-      assert InFlightExit.txbytes_to_id(to_binary("0x1234")) ==
+      assert InFlightExit.tx_bytes_to_id(to_binary("0x1234")) ==
                3_817_219_175_777_579_444_019_728_485_725_459_454_579_489_354
 
-      assert InFlightExit.txbytes_to_id(to_binary("0xb26f143eb9e68e5b")) ==
+      assert InFlightExit.tx_bytes_to_id(to_binary("0xb26f143eb9e68e5b")) ==
                4_423_187_252_251_026_420_447_811_542_410_043_191_383_319_711
 
-      assert InFlightExit.txbytes_to_id(to_binary("0x70de28d3cd1cb609")) ==
+      assert InFlightExit.tx_bytes_to_id(to_binary("0x70de28d3cd1cb609")) ==
                3_110_272_171_107_387_954_030_746_231_895_833_085_925_917_747
 
-      assert InFlightExit.txbytes_to_id(to_binary("0xc235a61a575eb3e2")) ==
+      assert InFlightExit.tx_bytes_to_id(to_binary("0xc235a61a575eb3e2")) ==
                5_361_575_098_523_492_156_916_835_341_228_175_600_149_117_682
 
-      assert InFlightExit.txbytes_to_id(to_binary("0x8fdeb13e6acdc74955fdcf0f345ae57a")) ==
+      assert InFlightExit.tx_bytes_to_id(to_binary("0x8fdeb13e6acdc74955fdcf0f345ae57a")) ==
                4_404_745_967_111_218_594_847_696_181_449_381_826_825_993_906
 
-      assert InFlightExit.txbytes_to_id(to_binary("0x00000000000000000000000000000000")) ==
+      assert InFlightExit.tx_bytes_to_id(to_binary("0x00000000000000000000000000000000")) ==
                5_581_496_182_896_756_123_499_329_818_246_993_621_247_309_773
 
-      assert InFlightExit.txbytes_to_id(to_binary("0xffffffffffffffffffffffffffffffff")) ==
+      assert InFlightExit.tx_bytes_to_id(to_binary("0xffffffffffffffffffffffffffffffff")) ==
                5_148_223_842_797_971_894_055_932_452_183_428_950_371_578_310
     end
   end


### PR DESCRIPTION
Simple PR to standardize variable naming from `txbytes` to tx_bytes`