### PR TITLE
Use :binary.decode_unsigned to convert amounts

### DIFF
--- a/lib/ex_plasma/output/type/payment_v1.ex
+++ b/lib/ex_plasma/output/type/payment_v1.ex
@@ -5,7 +5,6 @@ defmodule ExPlasma.Output.Type.PaymentV1 do
 
   @behaviour ExPlasma.Output
 
-  import ExPlasma.Encoding, only: [to_int: 1]
   alias ExPlasma.Output
 
   @type address() :: <<_::160>>
@@ -66,7 +65,7 @@ defmodule ExPlasma.Output.Type.PaymentV1 do
   def to_map([<<output_type>>, [output_guard, token, amount]]) do
     %{
       output_type: output_type,
-      output_data: %{output_guard: output_guard, token: token, amount: to_int(amount)}
+      output_data: %{output_guard: output_guard, token: token, amount: :binary.decode_unsigned(amount, :big)}
     }
   end
 

--- a/test/ex_plasma/output/types/payment_v1_test.exs
+++ b/test/ex_plasma/output/types/payment_v1_test.exs
@@ -5,6 +5,15 @@ defmodule ExPlasma.Output.Type.PaymentV1Test do
 
   alias ExPlasma.Output.Type.PaymentV1
 
+  describe "to_map/1" do
+    test "can decode amounts" do
+      output = %{output_type: 1, output_data: %{output_guard: <<1::160>>, token: <<1::160>>, amount: 12_408}}
+      rlp = PaymentV1.to_rlp(output)
+
+      assert %{output_data: %{amount: 12_408}} = PaymentV1.to_map(rlp)
+    end
+  end
+
   describe "validate/1" do
     test "that amount cannot be nil" do
       output = %{output_data: %{output_guard: <<1::160>>, token: <<0::160>>, amount: nil}}

--- a/test/ex_plasma/output/types/payment_v1_test.exs
+++ b/test/ex_plasma/output/types/payment_v1_test.exs
@@ -7,10 +7,10 @@ defmodule ExPlasma.Output.Type.PaymentV1Test do
 
   describe "to_map/1" do
     test "can decode amounts" do
-      output = %{output_type: 1, output_data: %{output_guard: <<1::160>>, token: <<1::160>>, amount: 12_408}}
-      rlp = PaymentV1.to_rlp(output)
-
-      assert %{output_data: %{amount: 12_408}} = PaymentV1.to_map(rlp)
+      Enum.map(1..65_000, fn amount ->
+        rlp = [<<1>>, [<<0::160>>, <<0::160>>, :binary.encode_unsigned(amount, :big)]]
+        assert %{output_data: %{amount: amount}} = PaymentV1.to_map(rlp)
+      end)
     end
   end
 

--- a/test/ex_plasma/output/types/payment_v1_test.exs
+++ b/test/ex_plasma/output/types/payment_v1_test.exs
@@ -14,6 +14,16 @@ defmodule ExPlasma.Output.Type.PaymentV1Test do
     end
   end
 
+  describe "to_rlp/1" do
+    test "can encode amounts" do
+      Enum.map(1..65_000, fn amount ->
+        output = %{output_type: 1, output_data: %{output_guard: <<1::160>>, token: <<0::160>>, amount: amount}}
+        encoded_amount = :binary.encode_unsigned(amount, :big)
+        assert [_, [_, _, ^encoded_amount]] = PaymentV1.to_rlp(output)
+      end)
+    end
+  end
+
   describe "validate/1" do
     test "that amount cannot be nil" do
       output = %{output_data: %{output_guard: <<1::160>>, token: <<0::160>>, amount: nil}}


### PR DESCRIPTION
:clipboard: closes https://github.com/omisego/ex_plasma/issues/55

This corrects how `ExPlasma` handles decoding amounts and uses `:binary.decode_unsigned/2` instead of `Encoding.to_int/1`